### PR TITLE
Add getGeometry function to Feature

### DIFF
--- a/geojson/api/android/geojson.api
+++ b/geojson/api/android/geojson.api
@@ -46,6 +46,7 @@ public final class io/github/elcolto/geokjson/geojson/Feature : io/github/elcolt
 	public fun getForeignMembers ()Ljava/util/Map;
 	public final fun getGeometry ()Lio/github/elcolto/geokjson/geojson/Geometry;
 	public final fun getId ()Ljava/lang/String;
+	public final fun getNonNullableGeometry ()Lio/github/elcolto/geokjson/geojson/Geometry;
 	public final fun getProperties ()Ljava/util/Map;
 	public fun hashCode ()I
 	public fun json ()Ljava/lang/String;

--- a/geojson/api/jvm/geojson.api
+++ b/geojson/api/jvm/geojson.api
@@ -46,6 +46,7 @@ public final class io/github/elcolto/geokjson/geojson/Feature : io/github/elcolt
 	public fun getForeignMembers ()Ljava/util/Map;
 	public final fun getGeometry ()Lio/github/elcolto/geokjson/geojson/Geometry;
 	public final fun getId ()Ljava/lang/String;
+	public final fun getNonNullableGeometry ()Lio/github/elcolto/geokjson/geojson/Geometry;
 	public final fun getProperties ()Ljava/util/Map;
 	public fun hashCode ()I
 	public fun json ()Ljava/lang/String;

--- a/geojson/src/commonMain/kotlin/io/github/elcolto/geokjson/geojson/Feature.kt
+++ b/geojson/src/commonMain/kotlin/io/github/elcolto/geokjson/geojson/Feature.kt
@@ -45,6 +45,14 @@ public data class Feature<out T : Geometry>(
     @JvmName("getPropertyCast")
     public inline fun <reified T : Any?> getProperty(key: String): T? = properties[key] as T?
 
+    /**
+     * Returns the [geometry] or throws an exception if it is `null`.
+     * @throws NoSuchElementException when the feature doesn't contain a geometry
+     */
+    @JvmName(name = "getNonNullableGeometry")
+    public inline fun getGeometry(): T = runCatching { geometry!! }
+        .getOrElse { throw NoSuchElementException("Feature has no geometry") }
+
     override fun toString(): String = json()
 
     private fun idProp(): String = if (this.id == null) "" else ""","id":"${this.id}""""

--- a/turf/src/commonMain/kotlin/io/github/elcolto/geokjson/turf/classification/NearestPoint.kt
+++ b/turf/src/commonMain/kotlin/io/github/elcolto/geokjson/turf/classification/NearestPoint.kt
@@ -118,9 +118,9 @@ public fun nearestPointFeature(
  * @returns the closest point in the set to the reference point.
  **/
 @ExperimentalTurfApi
-@Throws(IllegalArgumentException::class)
+@Throws(NoSuchElementException::class)
 public fun nearestPoint(target: Point, featureCollection: FeatureCollection): Point =
-    requireNotNull(nearestPointFeature(target, featureCollection).geometry)
+    nearestPointFeature(target, featureCollection).getGeometry()
 
 public object NearestPoint {
 

--- a/turf/src/commonMain/kotlin/io/github/elcolto/geokjson/turf/misc/LineSlice.kt
+++ b/turf/src/commonMain/kotlin/io/github/elcolto/geokjson/turf/misc/LineSlice.kt
@@ -24,10 +24,10 @@ public fun lineSlice(start: Position, stop: Position, line: LineString): LineStr
     var reverse = false
     val (startPos, endPos) =
         if (startIndex <= endIndex) {
-            startVertex.geometry!! to stopVertex.geometry!!
+            startVertex.getGeometry() to stopVertex.getGeometry()
         } else {
             reverse = true
-            stopVertex.geometry!! to startVertex.geometry!!
+            stopVertex.getGeometry() to startVertex.getGeometry()
         }
 
     val positions = mutableListOf(startPos)

--- a/turf/src/commonTest/kotlin/io/github/elcolto/geokjson/turf/coordinatemutation/CleanCoordinatesTest.kt
+++ b/turf/src/commonTest/kotlin/io/github/elcolto/geokjson/turf/coordinatemutation/CleanCoordinatesTest.kt
@@ -14,7 +14,7 @@ class CleanCoordinatesTest {
         val feature = Feature.fromJson<Geometry>(
             readResource("coordinatemutation/cleancoordinates/in/clean-segment.geojson"),
         )
-        val geometry = cleanCoordinates(feature.geometry!!)
+        val geometry = cleanCoordinates(feature.getGeometry())
         val expectedFeature = Feature.fromJson<Geometry>(
             readResource("coordinatemutation/cleancoordinates/out/clean-segment.geojson"),
         )
@@ -27,7 +27,7 @@ class CleanCoordinatesTest {
         val feature = Feature.fromJson<Geometry>(
             readResource("coordinatemutation/cleancoordinates/in/closed-linestring.geojson"),
         )
-        val geometry = cleanCoordinates(feature.geometry!!)
+        val geometry = cleanCoordinates(feature.getGeometry())
         val expectedFeature = Feature.fromJson<Geometry>(
             readResource("coordinatemutation/cleancoordinates/out/closed-linestring.geojson"),
         )
@@ -49,7 +49,7 @@ class CleanCoordinatesTest {
         val feature = Feature.fromJson<Geometry>(
             readResource("coordinatemutation/cleancoordinates/in/line-3-coords.geojson"),
         )
-        val geometry = cleanCoordinates(feature.geometry!!)
+        val geometry = cleanCoordinates(feature.getGeometry())
         val expectedFeature = Feature.fromJson<Geometry>(
             readResource("coordinatemutation/cleancoordinates/out/line-3-coords.geojson"),
         )
@@ -62,7 +62,7 @@ class CleanCoordinatesTest {
         val feature = Feature.fromJson<Geometry>(
             readResource("coordinatemutation/cleancoordinates/in/multiline.geojson"),
         )
-        val geometry = cleanCoordinates(feature.geometry!!)
+        val geometry = cleanCoordinates(feature.getGeometry())
         val expectedFeature = Feature.fromJson<Geometry>(
             readResource("coordinatemutation/cleancoordinates/out/multiline.geojson"),
         )
@@ -75,7 +75,7 @@ class CleanCoordinatesTest {
         val feature = Feature.fromJson<Geometry>(
             readResource("coordinatemutation/cleancoordinates/in/multipoint.geojson"),
         )
-        val geometry = cleanCoordinates(feature.geometry!!)
+        val geometry = cleanCoordinates(feature.getGeometry())
         val expectedFeature = Feature.fromJson<Geometry>(
             readResource("coordinatemutation/cleancoordinates/out/multipoint.geojson"),
         )
@@ -88,7 +88,7 @@ class CleanCoordinatesTest {
         val feature = Feature.fromJson<Geometry>(
             readResource("coordinatemutation/cleancoordinates/in/multipolygon.geojson"),
         )
-        val geometry = cleanCoordinates(feature.geometry!!)
+        val geometry = cleanCoordinates(feature.getGeometry())
         val expectedFeature = Feature.fromJson<Geometry>(
             readResource("coordinatemutation/cleancoordinates/out/multipolygon.geojson"),
         )
@@ -99,7 +99,7 @@ class CleanCoordinatesTest {
     @Test
     fun testPoint() {
         val feature = Feature.fromJson<Geometry>(readResource("coordinatemutation/cleancoordinates/in/point.geojson"))
-        val geometry = cleanCoordinates(feature.geometry!!)
+        val geometry = cleanCoordinates(feature.getGeometry())
         val expectedFeature = Feature.fromJson<Geometry>(
             readResource("coordinatemutation/cleancoordinates/out/point.geojson"),
         )
@@ -110,7 +110,7 @@ class CleanCoordinatesTest {
     @Test
     fun testPolygon() {
         val feature = Feature.fromJson<Geometry>(readResource("coordinatemutation/cleancoordinates/in/polygon.geojson"))
-        val geometry = cleanCoordinates(feature.geometry!!)
+        val geometry = cleanCoordinates(feature.getGeometry())
         val expectedFeature = Feature.fromJson<Geometry>(
             readResource("coordinatemutation/cleancoordinates/out/polygon.geojson"),
         )
@@ -123,7 +123,7 @@ class CleanCoordinatesTest {
         val feature = Feature.fromJson<Geometry>(
             readResource("coordinatemutation/cleancoordinates/in/polygon-with-hole.geojson"),
         )
-        val geometry = cleanCoordinates(feature.geometry!!)
+        val geometry = cleanCoordinates(feature.getGeometry())
         val expectedFeature = Feature.fromJson<Geometry>(
             readResource("coordinatemutation/cleancoordinates/out/polygon-with-hole.geojson"),
         )
@@ -134,7 +134,7 @@ class CleanCoordinatesTest {
     @Test
     fun testSegment() {
         val feature = Feature.fromJson<Geometry>(readResource("coordinatemutation/cleancoordinates/in/segment.geojson"))
-        val geometry = cleanCoordinates(feature.geometry!!)
+        val geometry = cleanCoordinates(feature.getGeometry())
         val expectedFeature = Feature.fromJson<Geometry>(
             readResource("coordinatemutation/cleancoordinates/out/segment.geojson"),
         )
@@ -147,7 +147,7 @@ class CleanCoordinatesTest {
         val feature = Feature.fromJson<Geometry>(
             readResource("coordinatemutation/cleancoordinates/in/simple-line.geojson"),
         )
-        val geometry = cleanCoordinates(feature.geometry!!)
+        val geometry = cleanCoordinates(feature.getGeometry())
         val expectedFeature = Feature.fromJson<Geometry>(
             readResource("coordinatemutation/cleancoordinates/out/simple-line.geojson"),
         )
@@ -160,7 +160,7 @@ class CleanCoordinatesTest {
         val feature = Feature.fromJson<Geometry>(
             readResource("coordinatemutation/cleancoordinates/in/triangle.geojson"),
         )
-        val geometry = cleanCoordinates(feature.geometry!!)
+        val geometry = cleanCoordinates(feature.getGeometry())
         val expectedFeature = Feature.fromJson<Geometry>(
             readResource("coordinatemutation/cleancoordinates/out/triangle.geojson"),
         )

--- a/turf/src/commonTest/kotlin/io/github/elcolto/geokjson/turf/grids/SquareGridTest.kt
+++ b/turf/src/commonTest/kotlin/io/github/elcolto/geokjson/turf/grids/SquareGridTest.kt
@@ -58,7 +58,7 @@ class SquareGridTest {
             Position(13.17194422502807, 52.515969323342695),
             Position(13.170147683370761, 52.515969323342695),
         )
-        assertEquals(expectedFistItem, grid.features.first().geometry!!.coordAll())
+        assertEquals(expectedFistItem, grid.features.first().getGeometry().coordAll())
         val expectedLastItem = mutableListOf(
             Position(13.18272347497193, 52.517765865),
             Position(13.18272347497193, 52.51956240665731),
@@ -66,7 +66,7 @@ class SquareGridTest {
             Position(13.18452001662924, 52.517765865),
             Position(13.18272347497193, 52.517765865),
         )
-        assertEquals(expectedLastItem, grid.features.last().geometry!!.coordAll())
+        assertEquals(expectedLastItem, grid.features.last().getGeometry().coordAll())
     }
 
     @OptIn(ExperimentalTurfApi::class)

--- a/turf/src/commonTest/kotlin/io/github/elcolto/geokjson/turf/measurement/CentroidTest.kt
+++ b/turf/src/commonTest/kotlin/io/github/elcolto/geokjson/turf/measurement/CentroidTest.kt
@@ -28,7 +28,7 @@ class CentroidTest {
     fun testImbalancePolygon() {
         val polygon = Feature.fromJson<Polygon>(
             readResource("measurement/centroid/in/imbalanced-polygon.geojson"),
-        ).geometry!!
+        ).getGeometry()
 
         val pos = centroid(polygon).coordinates
         assertDoubleEquals(4.851791984156558, pos.longitude, epsilon = 0.000001)
@@ -39,7 +39,7 @@ class CentroidTest {
     fun testLineString() {
         val lineString = Feature.fromJson<LineString>(
             readResource("measurement/centroid/in/linestring.geojson"),
-        ).geometry!!
+        ).getGeometry()
 
         val pos = centroid(lineString).coordinates
         assertDoubleEquals(4.860076904296875, pos.longitude, epsilon = 0.000001)
@@ -48,7 +48,7 @@ class CentroidTest {
 
     @Test
     fun testPoint() {
-        val point = Feature.fromJson<Point>(readResource("measurement/centroid/in/point.geojson")).geometry!!
+        val point = Feature.fromJson<Point>(readResource("measurement/centroid/in/point.geojson")).getGeometry()
 
         val pos = centroid(point).coordinates
         assertDoubleEquals(4.831961989402771, pos.longitude, epsilon = 0.000001)
@@ -57,7 +57,7 @@ class CentroidTest {
 
     @Test
     fun testPolygon() {
-        val polygon = Feature.fromJson<Polygon>(readResource("measurement/centroid/in/polygon.geojson")).geometry!!
+        val polygon = Feature.fromJson<Polygon>(readResource("measurement/centroid/in/polygon.geojson")).getGeometry()
 
         val pos = centroid(polygon).coordinates
         assertDoubleEquals(4.841194152832031, pos.longitude, epsilon = 0.000001)

--- a/turf/src/commonTest/kotlin/io/github/elcolto/geokjson/turf/measurement/DestinationTest.kt
+++ b/turf/src/commonTest/kotlin/io/github/elcolto/geokjson/turf/measurement/DestinationTest.kt
@@ -40,7 +40,7 @@ class DestinationTest {
             val distance = feature.properties["dist"].asInstance<Int>()?.toDouble() ?: 100.0
             val units = feature.properties["units"].asInstance<String>()?.let { Units.valueOf(it.capitalize()) }
                 ?: Units.Kilometers
-            val origin = feature.geometry!!.coordinates
+            val origin = feature.getGeometry().coordinates
 
             val destination = rhumbDestination(origin, distance, bearing, units)
 

--- a/turf/src/commonTest/kotlin/io/github/elcolto/geokjson/turf/transformation/ScaleTest.kt
+++ b/turf/src/commonTest/kotlin/io/github/elcolto/geokjson/turf/transformation/ScaleTest.kt
@@ -123,9 +123,9 @@ class ScaleTest {
         val scaleOrigin = originString?.let { stringToScaledOrigin(it, null) }
             ?: originPosition?.let { stringToScaledOrigin("coordinates", it) }
 
-        val scaledGeometry = scale(feature.geometry!!, factor.toDouble(), scaleOrigin ?: ScaleOrigin.Centroid)
+        val scaledGeometry = scale(feature.getGeometry(), factor.toDouble(), scaleOrigin ?: ScaleOrigin.Centroid)
 
-        assertGeometryEquals(expectedFc.features.first().geometry!!, scaledGeometry, 0.000001)
+        assertGeometryEquals(expectedFc.features.first().getGeometry(), scaledGeometry, 0.000001)
     }
 
     private fun stringToScaledOrigin(value: String, position: Position?): ScaleOrigin = when (value) {


### PR DESCRIPTION
Returns a `Geometry` from a feature unsafely without null check. If not present, exception will be thrown